### PR TITLE
add DeterministicAlgorithmChecker

### DIFF
--- a/dslinter/checkers/deterministic_pytorch.py
+++ b/dslinter/checkers/deterministic_pytorch.py
@@ -1,0 +1,56 @@
+"""Checker which checks whether deterministic algorithm is used."""
+import astroid
+from pylint.interfaces import IAstroidChecker
+from pylint.checkers import BaseChecker
+
+
+class DeterministicAlgorithmChecker(BaseChecker):
+    """Checker which checks whether deterministic algorithm is used."""
+
+    __implements__ = IAstroidChecker
+
+    name = "deterministic-pytorch"
+    priority = -1
+    msgs = {
+        "":(
+            "torch.use_deterministic_algorithm()  is not set to True",
+            "deterministic-pytorch",
+            "torch.use_deterministic_algorithm()  should be set to True during development process for reproducible result."
+        )
+    }
+    options = ()
+
+    _import_pytorch = False
+    _has_deterministic_algorithm_option = False
+
+    def visit_import(self, node: astroid.Import):
+        """
+        Check whether there is a pytorch import
+        :param node: import node
+        """
+        for name, alias in node.names:
+            if name == "torch":
+                self._import_pytorch = True
+
+    def visit_call(self, node: astroid.Call):
+        """
+        Check whether use_deterministic_algorithms option is used.
+        :param node: call node
+        """
+        # if torch.use_deterministic_algorithm() is call and the argument is True, set _has_deterministic_algorithm_option to True
+        if(
+            hasattr(node, "func")
+            and hasattr(node.func, "attrname")
+            and node.func.attrname == "use_deterministic_algorithms"
+            and hasattr(node, "args")
+            and len(node.args) > 0
+            and hasattr(node.args[0], "value")
+            and node.args[0].value == True
+        ):
+            self._has_deterministic_algorithm_option = True
+
+        if(
+            self._import_pytorch is True
+            and self._has_deterministic_algorithm_option is False
+        ):
+            self.add_message("deterministic-pytorch", node = node)

--- a/dslinter/plugin.py
+++ b/dslinter/plugin.py
@@ -5,6 +5,7 @@ from dslinter.checkers.inplace_numpy import InPlaceNumpyChecker
 from dslinter.checkers.memory_release_tensorflow import MemoryReleaseTensorflowChecker
 from dslinter.checkers.unnecessary_iteration_pandas import UnnecessaryIterationPandasChecker
 from dslinter.checkers.unnecessary_iteration_tensorflow import UnnecessaryIterationTensorflowChecker
+from dslinter.checkers.deterministic_pytorch import DeterministicAlgorithmChecker
 
 from dslinter.checkers.data_leakage import DataLeakageChecker
 from dslinter.checkers.hyperparameters_scikitlearn import HyperparameterScikitLearnChecker
@@ -27,6 +28,7 @@ def register(linter):
     linter.register_checker(ScalerMissingScikitLearnChecker(linter))
     linter.register_checker(HyperparameterScikitLearnChecker(linter))
     linter.register_checker(MemoryReleaseTensorflowChecker(linter))
+    linter.register_checker(DeterministicAlgorithmChecker(linter))
 
     linter.register_checker(NanChecker(linter))
     linter.register_checker(DataLeakageChecker(linter))

--- a/dslinter/test/checkers/test_deterministic_pytorch.py
+++ b/dslinter/test/checkers/test_deterministic_pytorch.py
@@ -1,0 +1,32 @@
+"""Class which tests DeterministicAlgorithmChecker."""
+import astroid
+import pylint.testutils
+import dslinter
+
+
+class TestDeterministicAlgorithmChecker(pylint.testutils.CheckerTestCase):
+    """Class which tests DeterministicAlgorithmChecker."""
+
+    CHECKER_CLASS = dslinter.plugin.DeterministicAlgorithmChecker
+
+    def test_with_deterministic_option_set(self):
+        """Test whether no message is added if the deterministic algorithm option is used."""
+        script = """
+        import torch #@
+        torch.use_deterministic_algorithms(True) #@
+        """
+        import_node, call_node = astroid.extract_node(script)
+        with self.assertNoMessages():
+            self.checker.visit_import(import_node)
+            self.checker.visit_call(call_node)
+
+    def test_without_deterministic_option_set(self):
+        """Test whether a message is added if the deterministic algorithm option is not used"""
+        script = """
+        import torch #@
+        torch.randn(10).index_copy(0, torch.tensor([0]), torch.randn(1)) #@
+        """
+        import_node, call_node = astroid.extract_node(script)
+        with self.assertAddsMessages(pylint.testutils.MessageTest(msg_id="deterministic-pytorch", node = call_node)):
+            self.checker.visit_import(import_node)
+            self.checker.visit_call(call_node)


### PR DESCRIPTION
Add DeterministicAlgorithmChecker #14.
The checkers check whether `torch.use_deterministic_algorithm()` is used when pytorch is import. But since the checker checks the rule for every files, it might produce a lot of false positives. `torch.use_deterministic_algorithm()` just need to show up once in a project.